### PR TITLE
Avoid endless loop in turtle on password change

### DIFF
--- a/usr/bin/change_password_gui
+++ b/usr/bin/change_password_gui
@@ -7,7 +7,13 @@ dialog --passwordbox "Enter a new password" 0 0 2>/tmp/pass.out
 
 [[ $? == 255 || $? == 1 ]] && {
     clear
-    exit
+    echo "There was a problem with the password prompt."
+    echo "It produced the following output:"
+    echo ""
+    cat /tmp/pass.out
+    echo ""
+    echo "End of output. Exiting."
+    exit 1
 } || {
     pass=$(cat /tmp/pass.out && rm /tmp/pass.out &> /dev/null)
 

--- a/usr/bin/turtle
+++ b/usr/bin/turtle
@@ -14,6 +14,10 @@ TURTLE_ASCII="          .-./*)            (*\.-.\n        _/___\/  LAN TURTLE  \
 while [ -f /etc/turtle/set_pass ]
 do
     change_password_gui
+    # if the exit code was 1, then there was a problem with the script
+    [[ $? == 1 ]] && {
+        exit 1
+    }
 done
 
 


### PR DESCRIPTION
Because of #7, the turtle script ran into an endless loop in my setup. I propose to check for the reason the password change failed before calling change_password_gui again.